### PR TITLE
[juan] fix featured images position at some routes

### DIFF
--- a/src/app/preguntas-frecuentes/faqPage.scss
+++ b/src/app/preguntas-frecuentes/faqPage.scss
@@ -1,0 +1,3 @@
+main > .backgroundPhoto--container > img {
+  object-position: right;
+}

--- a/src/app/preguntas-frecuentes/page.tsx
+++ b/src/app/preguntas-frecuentes/page.tsx
@@ -1,5 +1,6 @@
 import bgPhoto from '@/assets/images/preguntas-frecuentes/header-faq.webp';
 import BackgroundTopPhoto from '@/components/BackgroundTopPhoto';
+import './faqPage.scss';
 
 export default function FaqPage() {
   return (

--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -1,5 +1,6 @@
 import bgPhoto from '@/assets/images/tienda/header-tienda.webp';
 import BackgroundTopPhoto from '@/components/BackgroundTopPhoto';
+import './storePage.scss';
 
 export default function StorePage() {
   return (

--- a/src/app/tienda/storePage.scss
+++ b/src/app/tienda/storePage.scss
@@ -1,0 +1,3 @@
+main > .backgroundPhoto--container > img {
+  object-position: center;
+}


### PR DESCRIPTION
# Fix featured images position at some routes

## Description

All routes currently use `object-position: left`, but for some featured images on certain routes, it wasn't working properly

## Screenshots

* before
![image](https://github.com/J-HernandezM/ananda-web/assets/113635359/fc82f913-d163-4d3b-a04c-4e35c06d16f1)
* after
![image](https://github.com/J-HernandezM/ananda-web/assets/113635359/b7f73bc2-7dfc-4e0e-8226-8c37bb061dae)
