### PR TITLE
[juan] routing test at header

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -41,20 +41,27 @@ describe('<Header />', () => {
     });
   });
 
-  // TODO: confirm that this is a correct approach
-  test('Click at a Link should lead to a different route', async () => {
+  // TODO: consult if this approach is correct
+  // Explanation: without the change in href we get console.error wich is a test-only warning from a non implemented yet feature with JSDOM (navigation)
+  test('Click on a Link should produce a re render (in to a different route)', async () => {
     // Arrange
     const link = screen.getAllByRole('link', { name: 'Nosotros' })[0];
-    (usePathname as jest.Mock).mockReturnValue('/nosotros');
+    // Ensure link is an Anchor element
+    if (!(link instanceof HTMLAnchorElement)) { return; }
+
+    // To avoid console.error about jsdom not having navigation yet
+    link.href = `#${link.href.split('/').at(-1)}`;
 
     // Act
     await act(() => {
+      // Make the navigation (should produce a re-render)
       userEvent.click(link);
     });
 
     // Assert
     await waitFor(() => {
-      expect(usePathname()).toContain('/nosotros');
+      // If re-render happens to occur, then usePathname should be called
+      expect(usePathname).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Correcting test with routing at header

## Description
This test was giving a warning due to a not-yet implemented feature by jsdom, wich is the navigation.
To work around that i chose to change the `.href` parameter to an allowed one and also changed the assertion to verify if usePathname has been called since it will always be called when a re-render occurs and the click event on the Link component should reproduce that behavior.