### PR TITLE
[juan] adjust desktop sizes

### DIFF
--- a/src/components/BackgroundTopPhoto/backgroundTopPhoto.scss
+++ b/src/components/BackgroundTopPhoto/backgroundTopPhoto.scss
@@ -14,6 +14,7 @@
 
     @include for-tablet-portrait-up {
       width: 100%;
+      max-height: 75vh;
       height: auto;
     }
   }

--- a/src/components/FeaturedProducts/featuredProducts.scss
+++ b/src/components/FeaturedProducts/featuredProducts.scss
@@ -19,11 +19,11 @@
   @include font-titles;
 
   @include for-tablet-portrait-up {
-    font-size: 45px;
+    font-size: 36px;
   }
 
   @include screen-desktop {
-    font-size: 57px;
+    font-size: 45px;
   }
 }
 

--- a/src/components/FeaturedProducts/sliderFeaturedProducts.scss
+++ b/src/components/FeaturedProducts/sliderFeaturedProducts.scss
@@ -15,6 +15,10 @@
 
   @include for-tablet-portrait-up {
     width: 250px;
+    padding: 16px;
+  }
+
+  @include screen-desktop {
     padding: 24px;
   }
 }
@@ -42,10 +46,6 @@
 
   @include for-tablet-portrait-up {
     font-size: var(--sm);
-  }
-
-  @include screen-desktop {
-    font-size: var(--md);
   }
 }
 

--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -15,10 +15,6 @@ header {
 
 .icons {
   width: 24px;
-
-  @include for-tablet-portrait-up {
-    width: 34px;
-  }
 }
 
 .header--menu-icon {
@@ -28,9 +24,15 @@ header {
 }
 
 .header--logo-icon {
-  width: 8vw;
-  min-width: 40px;
-  max-width: 70px;
+  width: 40px;
+
+  @include for-tablet-portrait-up {
+    width: 50px;
+  }
+
+  @include screen-desktop {
+    width: 56px;
+  }
 }
 
 .header--icon-container {

--- a/src/components/HomeFeaturedSection/homeFeaturedSection.scss
+++ b/src/components/HomeFeaturedSection/homeFeaturedSection.scss
@@ -13,6 +13,10 @@
   @include for-tablet-portrait-up {
     left: 12.5%;
   }
+
+  @include screen-desktop {
+    left: 20%;
+  }
 }
 
 .featured--title {
@@ -22,11 +26,11 @@
 
   @include font-titles;
   @include for-tablet-portrait-up {
-    font-size: 60px;
+    font-size: 57px;
   }
 
   @include screen-desktop {
-    font-size: 112px;
+    font-size: 64px;
   }
 }
 
@@ -34,16 +38,15 @@
   color: var(--c-linen);
   font-size: 20px;
   margin: -8px 0 10px;
+  max-width: 70%;
 
   @include font-texts;
   @include for-tablet-portrait-up {
-    max-width: 400px;
     font-size: 28px;
     margin: -16px 0 10px;
   }
   @include screen-desktop {
-    max-width: 750px;
-    font-size: 50px;
+    font-size: 32px;
     margin: -24 0 20px;
   }
 }

--- a/src/components/HomeFirstSection/homeFirstSection.scss
+++ b/src/components/HomeFirstSection/homeFirstSection.scss
@@ -11,11 +11,11 @@
   margin-bottom: 48px;
 
   @include for-tablet-portrait-up {
-    margin-bottom: 220px;
+    margin-bottom: 76px;
   }
 
   @include screen-desktop {
-    padding-top: 88px;
+    padding-top: 64px;
   }
 }
 
@@ -32,8 +32,8 @@
 }
 
 .firstSection--logo-text {
-  width: 40%;
-  max-width: 780px;
+  width: 45%;
+  max-width: 400px;
   min-width: 250px;
   height: auto;
 }
@@ -55,11 +55,15 @@
   justify-content: center;
 
   width: 80%;
-  max-width: 880px;
+  max-width: 550px;
   min-width: 320px;
-  margin: 50px 0px;
+  margin: 12px 0px 24px;
   aspect-ratio: 6/5;
   height: auto;
+
+  @include screen-desktop {
+    margin: 28px 0px;
+  }
 }
 
 .firstSection--logo-hands {
@@ -91,18 +95,18 @@ p.firstSection--description {
   @include font-titles;
 
   @include for-tablet-portrait-up {
-    font-size: var(--xl);
-  }
-
-  @include screen-desktop {
-    font-size: 46px;
+    font-size: 24px;
   }
 }
 
 .collage--images-box {
   position: absolute;
-  bottom: 0;
+  bottom: 0px;
   width: 100%;
+
+  @include screen-desktop {
+    bottom: 30px;
+  }
 }
 
 .collage--asset {

--- a/src/components/HomeFirstSection/homeFirstSection.scss
+++ b/src/components/HomeFirstSection/homeFirstSection.scss
@@ -27,7 +27,7 @@
   z-index: 2;
 
   width: 7%;
-  max-width: 130px;
+  max-width: 100px;
   min-width: 70px;
 }
 

--- a/src/shared/components/StyledButton/styledButton.scss
+++ b/src/shared/components/StyledButton/styledButton.scss
@@ -14,7 +14,6 @@
 
   @include screen-desktop {
     padding: 10px 14px;
-    // font-size: 18;
     gap: 13px;
   }
 }
@@ -23,8 +22,4 @@
   width: 14px;
   height: auto;
   margin-top: 4px;
-
-  // @include screen-desktop {
-  //   width: 24px;
-  // }
 }

--- a/src/shared/components/StyledButton/styledButton.scss
+++ b/src/shared/components/StyledButton/styledButton.scss
@@ -9,12 +9,12 @@
   position: relative;
   align-items: center;
   padding: 6px 10px;
-  font-size: 20px;
+  font-size: 18px;
   gap: 8px;
 
   @include screen-desktop {
-    padding: 18px 24px;
-    font-size: var(--text);
+    padding: 10px 14px;
+    // font-size: 18;
     gap: 13px;
   }
 }
@@ -24,7 +24,7 @@
   height: auto;
   margin-top: 4px;
 
-  @include screen-desktop {
-    width: 24px;
-  }
+  // @include screen-desktop {
+  //   width: 24px;
+  // }
 }


### PR DESCRIPTION
# Several sizes adjustments

## Description

The desktop version of the web was getting too invasive for the user with smaller desktop screens because of the huge sizes of some elements and fonts, reduced all in general following the styles provided in figma

## GIF

* BEFORE
![AnandaJaboneriaArtesanal-Opera2024-06-2400-11-46-ezgif com-video-to-gif-converter](https://github.com/J-HernandezM/ananda-web/assets/113635359/0a78e57b-50f8-4b1d-a62c-c7e81da178a0)


* AFTER
![AnandaJaboneriaArtesanal-Opera2024-06-2323-58-44-ezgif com-video-to-gif-converter](https://github.com/J-HernandezM/ananda-web/assets/113635359/a1f29a40-f08e-4924-8695-fe7f68305c60)
