### PR TITLE
[juan] fix grid spacing at product detail interest section

### DIFF
--- a/src/app/productos/[productId]/productDetail.scss
+++ b/src/app/productos/[productId]/productDetail.scss
@@ -135,7 +135,7 @@
 }
 
 .interest {
-  padding: 20px;
+  padding: 20px 12px;
 
   @include for-tablet-portrait-up {
     padding: 20px 40px 40px;


### PR DESCRIPTION
# Grid spacing at interest section on /productos/*

While navigating trough /productos/:id on some devices the grid inside interest section had only 1 column, reduced padding to match design